### PR TITLE
Create a test stage/task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,13 @@ watch:
 	-i module-playbook.yml 'content/**' \
 	-- antora generate module-playbook.yml
 
+# test: @ Run checks that prove/disprove the source is ready for release
+define test_tasks
+pyspelling -c .spellcheck.yml
+endef
+test:
+	docker-compose run -u $$(id -u) antora $(test_tasks)
+
 # shell: @ Opens bash shell in antora container
 shell: CMD ?= /bin/sh
 shell:

--- a/antora.dockerfile
+++ b/antora.dockerfile
@@ -1,3 +1,12 @@
 FROM antora/antora:2.3.4
 RUN yarn global add http-server onchange
+
+# install build depdencies for pyspelling
+RUN apk add --no-cache \
+	bash build-base python3 python3-dev libxml2-dev libxslt-dev
+
+# install pyspelling
+RUN apk add aspell aspell-en
+RUN pip3 install pyspelling
+
 WORKDIR /site


### PR DESCRIPTION
A `make test` task that will execute the pyspelling check that's part of
our pipeline.

Since it's useful to be able to run all stages of our pipeline locally,
the `antora.dockerfile` has been enhanced to support running `pyspelling`.

This is at the cost of additional setup/dependencies on initial building
of the image.

- add `pyspelling` and its dependencies to `anotora.dockerfile`
- define a `test_tasks` list of commands to be run inside container